### PR TITLE
Use an origami component (o-brand) as a peer dependency

### DIFF
--- a/main.scss
+++ b/main.scss
@@ -1,6 +1,8 @@
 @import "mathsass/dist/math";
+@import "@financial-times/o-brand";
 
 @import './src/scss/variables';
+@import './src/scss/brand';
 @import './src/scss/functions';
 
 /// Output all o-test-component styles.
@@ -9,7 +11,7 @@
 		padding: 0.5em 1em;
 		background-color: pink;
 		&:after {
-			content: 'The square root of 64 is "#{oTestComponentSquareRoot(64)}".';
+			content: _oTestComponentGet('content') + ' The square root of 64 is "#{oTestComponentSquareRoot(64)}".';
 		}
 	}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "npm": ">=7"
       },
       "peerDependencies": {
+        "@financial-times/o-brand": "^4.0.0-beta.0",
         "mathsass": "^0.11.0"
       }
     },
@@ -366,6 +367,15 @@
       },
       "engines": {
         "node": "^10.12.0 || >=12.0.0"
+      }
+    },
+    "node_modules/@financial-times/o-brand": {
+      "version": "4.0.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@financial-times/o-brand/-/o-brand-4.0.0-beta.0.tgz",
+      "integrity": "sha512-9IoI1boVfo6yzcUBs9wDP8cVhpR/2PIsTGTC1V0FHblHJ7GX3Vu4iJ0pLtq8F/52CcnvL685wnqyBF28T77vXg==",
+      "peer": true,
+      "engines": {
+        "npm": "^7"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -5829,6 +5839,12 @@
         "minimatch": "^3.0.4",
         "strip-json-comments": "^3.1.1"
       }
+    },
+    "@financial-times/o-brand": {
+      "version": "4.0.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@financial-times/o-brand/-/o-brand-4.0.0-beta.0.tgz",
+      "integrity": "sha512-9IoI1boVfo6yzcUBs9wDP8cVhpR/2PIsTGTC1V0FHblHJ7GX3Vu4iJ0pLtq8F/52CcnvL685wnqyBF28T77vXg==",
+      "peer": true
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.4",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "lodash-es": "^4.17.20"
   },
   "peerDependencies": {
+    "@financial-times/o-brand": "^4.0.0-beta.0",
     "mathsass": "^0.11.0"
   }
 }

--- a/src/scss/_brand.scss
+++ b/src/scss/_brand.scss
@@ -1,0 +1,38 @@
+/// Helper for `o-brand` function.
+/// @access private
+@function _oTestComponentGet($variables, $from: null) {
+	@return oBrandGet($component: 'o-test-component', $variables: $variables, $from: $from);
+}
+
+/// Helper for `o-brand` function.
+/// @access private
+@function _oTestComponentSupports($variant) {
+	@return oBrandSupportsVariant($component: 'o-test-component', $variant: $variant);
+}
+
+@if oBrandGetCurrentBrand() == 'master' {
+	@include oBrandDefine('o-test-component', 'master', (
+		'variables': (
+			'content': 'Hello world! '
+		),
+		'supports-variants': ()
+	));
+}
+
+@if oBrandGetCurrentBrand() == 'internal' {
+	@include oBrandDefine('o-test-component', 'internal', (
+		'variables': (
+			'content': 'Hello employee 317. Hope you find this internal tool or product helpful.'
+		),
+		'supports-variants': ()
+	));
+}
+
+@if oBrandGetCurrentBrand() == 'whitelabel' {
+	@include oBrandDefine('o-test-component', 'whitelabel', (
+		'variables': (
+			'content': ''
+		),
+		'supports-variants': ()
+	));
+}


### PR DESCRIPTION
As well as showing how imports have changed for Origami Sass since
moving to v2 of the specification, this test component can be used
to test tools/services with v2 components when they interact with
brands -- e.g. origami-bundle-size-cli