### PR TITLE
Make the demo sass cause the compiler to error due to invalid syntax

### DIFF
--- a/demos/src/demo.scss
+++ b/demos/src/demo.scss
@@ -1,3 +1,5 @@
 @import '../../';
 
 @include oTestComponent();
+
+{137}

--- a/demos/src/test-demo.mustache
+++ b/demos/src/test-demo.mustache
@@ -1,3 +1,1 @@
-<div data-o-component="o-test-component" class="o-test-component">
-{{#causing-syntax-error-by-not-closing-section}}
-</div>
+<div data-o-component="o-test-component" class="o-test-component"></div>

--- a/readme.md
+++ b/readme.md
@@ -29,6 +29,7 @@ To learn about getting started with other Origami components see the [Origami co
 |2.0.8  | Yes    | Yes      | No       | Yes       | Yes        | Yes         | Yes           |                                               |
 |2.0.9  | Yes    | Yes      | Yes      | Yes       | Yes        | Yes         | Yes           |                                               |
 |2.0.10 | Yes    | Yes      | Yes      | No        | Yes        | Yes         | Yes           | The demo's mustache causes a compilation error|
+|2.0.11 | Yes    | Yes      | Yes      | No        | Yes        | Yes         | Yes           | The demo's sass causes a compilation error    |
 
 
 ----


### PR DESCRIPTION
This will be used in the tests for the origami build tools and build service