### PR TITLE
Add test for missing primary mixin.

### DIFF
--- a/.stylelintignore
+++ b/.stylelintignore
@@ -1,0 +1,1 @@
+demos/local/**

--- a/.stylelintrc.cjs
+++ b/.stylelintrc.cjs
@@ -1,0 +1,3 @@
+module.exports = {
+    "extends": "stylelint-config-origami-component"
+};

--- a/demos/src/demo.js
+++ b/demos/src/demo.js
@@ -1,5 +1,1 @@
 import '../../main.js';
-
-document.addEventListener("DOMContentLoaded", function () {
-	document.dispatchEvent(new CustomEvent('o.DOMContentLoaded'));
-});

--- a/demos/src/demo.scss
+++ b/demos/src/demo.scss
@@ -1,0 +1,5 @@
+@import '../../main';
+
+@include oTestComponentPartOne() {
+	@include oTestComponentPartTwo();
+}

--- a/demos/src/test-demo.mustache
+++ b/demos/src/test-demo.mustache
@@ -1,3 +1,2 @@
 <div data-o-component="o-test-component" class="o-test-component">
-</P/>Hello world!</P>
 </div>

--- a/main.scss
+++ b/main.scss
@@ -1,0 +1,23 @@
+@import "mathsass/dist/math";
+@import "@financial-times/o-brand/main";
+
+@import './src/scss/brand';
+@import './src/scss/functions';
+
+/// Output some o-test-component styles.
+/// No primary mixin, required by v2 of the Origami specification.
+@mixin oTestComponentPartOne() {
+	.o-test-component {
+		padding: 0.5em 1em;
+		background-color: pink;
+		@content;
+	}
+}
+
+/// Output some more o-test-component styles.
+/// No primary mixin, required by v2 of the Origami specification.
+@mixin oTestComponentPartTwo() {
+	&:after {
+		content: _oTestComponentGet('content') + ' The square root of 64 is "#{oTestComponentSquareRoot(64)}".';
+	}
+}

--- a/origami.json
+++ b/origami.json
@@ -9,7 +9,8 @@
 		"slack": "financialtimes/origami-support"
 	},
 	"demosDefaults": {
-		"js": "demos/src/demo.js"
+		"js": "demos/src/demo.js",
+		"sass": "demos/src/demo.scss"
 	},
 	"demos": [
 		{

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@financial-times/o-test-component",
-  "version": "2.2.16",
+  "version": "2.2.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@financial-times/o-test-component",
-      "version": "2.2.16",
+      "version": "2.2.9",
       "license": "MIT",
       "dependencies": {
         "lodash-es": "^4.17.20"
@@ -25,7 +25,8 @@
         "npm": ">=7"
       },
       "peerDependencies": {
-        "@financial-times/o-brand": "prerelease"
+        "@financial-times/o-brand": "prerelease",
+        "mathsass": "^0.11.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2585,6 +2586,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/mathsass": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/mathsass/-/mathsass-0.11.0.tgz",
+      "integrity": "sha512-aU4p90yvQNmIF4jLNh2ojqgwi6UmDLv11JnwhvLb731/kLPHz45i65CqKBq/W5sgPobnbG0kZszTb4TdNzywcQ==",
+      "peer": true,
+      "engines": {
+        "node": ">=0.8.0",
+        "npm": ">=1.2.10"
       }
     },
     "node_modules/mdast-comment-marker": {
@@ -7318,6 +7329,12 @@
       "resolved": "https://registry.npmjs.org/mathml-tag-names/-/mathml-tag-names-2.1.3.tgz",
       "integrity": "sha512-APMBEanjybaPzUrfqU0IMU5I0AswKMH7k8OTLs0vvV4KZpExkTkY87nR/zpbuTPj+gARop7aGUbl11pnDfW6xg==",
       "dev": true
+    },
+    "mathsass": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/mathsass/-/mathsass-0.11.0.tgz",
+      "integrity": "sha512-aU4p90yvQNmIF4jLNh2ojqgwi6UmDLv11JnwhvLb731/kLPHz45i65CqKBq/W5sgPobnbG0kZszTb4TdNzywcQ==",
+      "peer": true
     },
     "mdast-comment-marker": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@financial-times/o-test-component",
-  "version": "2.2.16",
+  "version": "0.0.0",
   "description": "A component used to test origami tools and services",
   "keywords": [],
   "homepage": "https://registry.origami.ft.com/components/o-test-component",
@@ -42,7 +42,8 @@
     "lodash-es": "^4.17.20"
   },
   "peerDependencies": {
-    "@financial-times/o-brand": "prerelease"
+    "@financial-times/o-brand": "prerelease",
+    "mathsass": "^0.11.0"
   },
   "volta": {
     "node": "14.16.1",

--- a/readme.md
+++ b/readme.md
@@ -14,7 +14,6 @@ Each release of this component is used to test a different scenario in the Origa
 
 To learn about getting started with other Origami components see the [Origami component documentation](https://origami.ft.com/docs/components).
 
-
 ## Versions
 
 |version|valid js|valid sass|valid html|valid demos|valid readme|js tests pass|sass tests pass|js lint passes|sass lint passes|valid origami.json  |description                      |
@@ -35,6 +34,7 @@ To learn about getting started with other Origami components see the [Origami co
 |2.2.14 | No     | Yes      | Yes      | Yes       | Yes        | Yes         | Yes           | No           | Yes            | Yes  | Syntax errors in component js                 |
 |2.2.15 | Yes    | Yes      | No       | Yes       | Yes        | Yes         | Yes           | Yes          | Yes            | Yes  | The demo html contains invalid syntax which causes prettier to throw an error |
 |2.2.16 | Yes    | -        | No       | Yes       | Yes        | Yes         | -             | Yes          | Yes            | Yes  |                                               |
+|2.2.17 | Yes    | No       | Yes      | Yes       | Yes        | Yes         | Yes           | Yes          | Yes            | Yes  | Missing the primary mixin `oTestComponentNotAPrimaryMixin`, required by v2 of the Origami specification |
 
 _2.2.1 introduces a Sass linting error not present in 2.0.1 or 2.1.1. Otherwise 2.0.x and 2.1.x match the corresponding patch version in the table above. However they have a number of additional failures related to [changes made](https://github.com/Financial-Times/o-test-component/pull/147) in the draft v2 version of the Origami specification, including an invalid `origamiVersion` in `origami.json` for 2.0.x test components._
 

--- a/src/scss/_brand.scss
+++ b/src/scss/_brand.scss
@@ -1,0 +1,38 @@
+/// Helper for `o-brand` function.
+/// @access private
+@function _oTestComponentGet($variables, $from: null) {
+	@return oBrandGet($component: 'o-test-component', $variables: $variables, $from: $from);
+}
+
+/// Helper for `o-brand` function.
+/// @access private
+@function _oTestComponentSupports($variant) {
+	@return oBrandSupportsVariant($component: 'o-test-component', $variant: $variant);
+}
+
+@if oBrandGetCurrentBrand() == 'master' {
+	@include oBrandDefine('o-test-component', 'master', (
+		'variables': (
+			'content': 'Hello world! '
+		),
+		'supports-variants': ()
+	));
+}
+
+@if oBrandGetCurrentBrand() == 'internal' {
+	@include oBrandDefine('o-test-component', 'internal', (
+		'variables': (
+			'content': 'Hello employee 317. Hope you find this internal tool or product helpful.'
+		),
+		'supports-variants': ()
+	));
+}
+
+@if oBrandGetCurrentBrand() == 'whitelabel' {
+	@include oBrandDefine('o-test-component', 'whitelabel', (
+		'variables': (
+			'content': ''
+		),
+		'supports-variants': ()
+	));
+}

--- a/src/scss/_functions.scss
+++ b/src/scss/_functions.scss
@@ -1,0 +1,8 @@
+/// Get the square root of a given number.
+// @param {Number} The number to find a square root for.
+// @return {Number}
+// @example
+//     oTestComponentSquareRoot(64); // 8
+@function oTestComponentSquareRoot($number) {
+	@return sqrt($number);
+}

--- a/test/scss/functions.test.scss
+++ b/test/scss/functions.test.scss
@@ -1,0 +1,5 @@
+@include describe('oTestComponentSquareRoot') {
+	@include it('returns the square root of a number') {
+		@include assert-equal(oTestComponentSquareRoot(2), 1.4142135624, $inspect: true);
+	}
+}

--- a/test/scss/index.test.scss
+++ b/test/scss/index.test.scss
@@ -1,0 +1,4 @@
+@import 'true';
+@import '../../main';
+
+@import 'functions.test';


### PR DESCRIPTION
The current pre-release of origami-build-tools will let this pass,
it shouldn't, and this test component may be used in an integration
test.