### PR TITLE
Add test for default CSS output.

### DIFF
--- a/demos/src/demo.scss
+++ b/demos/src/demo.scss
@@ -1,5 +1,1 @@
 @import '../../main';
-
-@include oTestComponentPartOne() {
-	@include oTestComponentPartTwo();
-}

--- a/main.scss
+++ b/main.scss
@@ -4,20 +4,18 @@
 @import './src/scss/brand';
 @import './src/scss/functions';
 
-/// Output some o-test-component styles.
-/// No primary mixin, required by v2 of the Origami specification.
-@mixin oTestComponentPartOne() {
+/// Output all o-test-component styles.
+@mixin oTestComponent() {
 	.o-test-component {
 		padding: 0.5em 1em;
 		background-color: pink;
-		@content;
+		&:after {
+			content: _oTestComponentGet('content') + ' The square root of 64 is "#{oTestComponentSquareRoot(64)}".';
+		}
 	}
 }
 
-/// Output some more o-test-component styles.
-/// No primary mixin, required by v2 of the Origami specification.
-@mixin oTestComponentPartTwo() {
-	&:after {
-		content: _oTestComponentGet('content') + ' The square root of 64 is "#{oTestComponentSquareRoot(64)}".';
-	}
-}
+/// Output o-test-component styles on import.
+/// This is not allowed according to v2 of the Origami specification.
+/// No CSS should be output until the Sass API is used, e.g. a mixin included.
+@include oTestComponent();

--- a/readme.md
+++ b/readme.md
@@ -35,6 +35,7 @@ To learn about getting started with other Origami components see the [Origami co
 |2.2.15 | Yes    | Yes      | No       | Yes       | Yes        | Yes         | Yes           | Yes          | Yes            | Yes  | The demo html contains invalid syntax which causes prettier to throw an error |
 |2.2.16 | Yes    | -        | No       | Yes       | Yes        | Yes         | -             | Yes          | Yes            | Yes  |                                               |
 |2.2.17 | Yes    | No       | Yes      | Yes       | Yes        | Yes         | Yes           | Yes          | Yes            | Yes  | Missing the primary mixin `oTestComponentNotAPrimaryMixin`, required by v2 of the Origami specification |
+|2.2.18 | Yes    | No       | Yes      | Yes       | Yes        | Yes         | Yes           | Yes          | Yes            | Yes  | CSS is output by the sass by default on import, which is not allowed according to the Origami specification |
 
 _2.2.1 introduces a Sass linting error not present in 2.0.1 or 2.1.1. Otherwise 2.0.x and 2.1.x match the corresponding patch version in the table above. However they have a number of additional failures related to [changes made](https://github.com/Financial-Times/o-test-component/pull/147) in the draft v2 version of the Origami specification, including an invalid `origamiVersion` in `origami.json` for 2.0.x test components._
 


### PR DESCRIPTION
For spec v2 components, no CSS should be output until the Sass API is used,
e.g. the primary mixin is included.
https://github.com/Financial-Times/origami-website/pull/273/files#r626746297