### PR TITLE
Add v3 as a working component.

### DIFF
--- a/demos/src/demo.js
+++ b/demos/src/demo.js
@@ -1,0 +1,1 @@
+import '../../main.js';

--- a/demos/src/demo.scss
+++ b/demos/src/demo.scss
@@ -1,0 +1,3 @@
+@import '../../main';
+
+@include oTestComponent();

--- a/demos/src/test-demo.mustache
+++ b/demos/src/test-demo.mustache
@@ -1,0 +1,2 @@
+<div data-o-component="o-test-component" class="o-test-component">
+</div>

--- a/main.scss
+++ b/main.scss
@@ -1,0 +1,16 @@
+@import "mathsass/dist/math";
+@import "@financial-times/o-brand/main";
+
+@import './src/scss/brand';
+@import './src/scss/functions';
+
+/// Output all o-test-component styles.
+@mixin oTestComponent() {
+	.o-test-component {
+		padding: 0.5em 1em;
+		background-color: pink;
+		&:after {
+			content: _oTestComponentGet('content') + ' The square root of 64 is "#{oTestComponentSquareRoot(64)}".';
+		}
+	}
+}

--- a/origami.json
+++ b/origami.json
@@ -1,13 +1,30 @@
 {
 	"supportStatus": "deprecated",
-	"origamiType": "library",
-	"description": "A project used to test origami tools and services",
+	"origamiType": "component",
+	"description": "A component used to test origami tools and services",
 	"origamiVersion": "2.0",
 	"support": "origami.support@ft.com",
 	"supportContact": {
 		"email": "origami.support@ft.com",
 		"slack": "financialtimes/origami-support"
 	},
-	"demosDefaults": {},
-	"demos": []
+	"demosDefaults": {
+		"js": "demos/src/demo.js",
+		"sass": "demos/src/demo.scss"
+	},
+	"demos": [
+		{
+			"title": "Test Demo",
+			"name": "test-demo",
+			"template": "demos/src/test-demo.mustache",
+			"description": "This demo shows the test component in action."
+		},
+		{
+			"title": "Pa11y",
+			"name": "pa11y",
+			"template": "demos/src/test-demo.mustache",
+			"hidden": true,
+			"description": "Used to run automated accessibility tests against."
+		}
+	]
 }

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "lodash-es": "^4.17.20"
   },
   "peerDependencies": {
+    "@financial-times/o-brand": "prerelease",
     "mathsass": "^0.11.0"
   },
   "volta": {

--- a/readme.md
+++ b/readme.md
@@ -40,8 +40,11 @@ To learn about getting started with other Origami components see the [Origami co
 |2.2.21 | Yes    | No       | Yes      | -         | Yes        | Yes         | Yes           | Yes          | Yes            | Yes                | library    | CSS is output by the sass by default on import |
 |2.2.22 | Yes    | -        | Yes      | -         | Yes        | Yes         | -             | Yes          | -              | Yes                | library    | Has no css and is a library not a component |
 |2.2.23 | Yes    | -        | Yes      | -         | Yes        | Yes         | -             | Yes          | -              | Yes                | library    | Same as 2.2.22 |
+|3.0.0  | Yes    | Yes      | Yes      | Yes       | Yes        | Yes         | Yes           | Yes          | Yes            | Yes                | component  | ✅ All correct.                                |
 
 _2.2.1 introduces a Sass linting error not present in 2.0.1 or 2.1.1. Otherwise 2.0.x and 2.1.x match the corresponding patch version in the table above, up to 2.2.16. However they have a number of additional failures related to changes made since v1 of the Origami specification._
+
+_3.0.0 is a valid component the same as 2.2.9. It is used to test tooling (Origami Build Service, URL updater) which provides guidance to users regarding the migration to npm-only components, which drop support for bower. 3.0.0 represents a major release on top of the 2.0.0 major used to test npm-only components._
 
 ***
 

--- a/src/scss/_brand.scss
+++ b/src/scss/_brand.scss
@@ -1,0 +1,38 @@
+/// Helper for `o-brand` function.
+/// @access private
+@function _oTestComponentGet($variables, $from: null) {
+	@return oBrandGet($component: 'o-test-component', $variables: $variables, $from: $from);
+}
+
+/// Helper for `o-brand` function.
+/// @access private
+@function _oTestComponentSupports($variant) {
+	@return oBrandSupportsVariant($component: 'o-test-component', $variant: $variant);
+}
+
+@if oBrandGetCurrentBrand() == 'master' {
+	@include oBrandDefine('o-test-component', 'master', (
+		'variables': (
+			'content': 'Hello world! '
+		),
+		'supports-variants': ()
+	));
+}
+
+@if oBrandGetCurrentBrand() == 'internal' {
+	@include oBrandDefine('o-test-component', 'internal', (
+		'variables': (
+			'content': 'Hello employee 317. Hope you find this internal tool or product helpful.'
+		),
+		'supports-variants': ()
+	));
+}
+
+@if oBrandGetCurrentBrand() == 'whitelabel' {
+	@include oBrandDefine('o-test-component', 'whitelabel', (
+		'variables': (
+			'content': ''
+		),
+		'supports-variants': ()
+	));
+}

--- a/src/scss/_functions.scss
+++ b/src/scss/_functions.scss
@@ -1,0 +1,8 @@
+/// Get the square root of a given number.
+// @param {Number} The number to find a square root for.
+// @return {Number}
+// @example
+//     oTestComponentSquareRoot(64); // 8
+@function oTestComponentSquareRoot($number) {
+	@return sqrt($number);
+}

--- a/test/scss/functions.test.scss
+++ b/test/scss/functions.test.scss
@@ -1,0 +1,5 @@
+@include describe('oTestComponentSquareRoot') {
+	@include it('returns the square root of a number') {
+		@include assert-equal(oTestComponentSquareRoot(2), 1.4142135624, $inspect: true);
+	}
+}

--- a/test/scss/index.test.scss
+++ b/test/scss/index.test.scss
@@ -1,0 +1,4 @@
+@import 'true';
+@import '../../main';
+
+@import 'functions.test';


### PR DESCRIPTION
3.0.0 is a valid component the same as 2.2.9. It is used to test tooling
(Origami Build Service, URL updater) which provides guidance to users
regarding the migration to npm-only components, which drop support for
bower. 3.0.0 represents a major release on top of the 2.0.0 major used
to test npm-only components.